### PR TITLE
fix: package.json script and publishing issues

### DIFF
--- a/.github/workflows/release-bun-library.yml
+++ b/.github/workflows/release-bun-library.yml
@@ -13,3 +13,4 @@ jobs:
     uses: flowscripter/.github/.github/workflows/release-bun-library.yml@v1
     secrets:
       PUSH_TO_MAIN_TOKEN: ${{ secrets.PUSH_TO_MAIN_TOKEN }}
+      NPM_TOKEN: ${{ secrets.PUSH_TO_MAIN_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/mpeggroup/mpeg-sdl-parser.git"
   },
   "scripts": {
-    "generate": "node_modules/.bin/lezer-generator --typeScript --output src/lezer/parser ./grammar/sdl.lezer.grammar"
+    "generate": "lezer-generator --typeScript --output src/lezer/parser ./grammar/sdl.lezer.grammar"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Update the package.json script to use the local `lezer-generator` command and adjust the workflow to include the correct NPM token for publishing.