### PR TITLE
fix: import AstPath as type-only from prettier

### DIFF
--- a/src/prettier/print-abstract-expression.ts
+++ b/src/prettier/print-abstract-expression.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc, doc } from "prettier";
+import { type AstPath, type Doc, doc } from "prettier";
 import { addBreakingWhitespace, addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractExpression } from "../ast/node/abstract-expression.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";

--- a/src/prettier/print-abstract-statement.ts
+++ b/src/prettier/print-abstract-statement.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc, doc } from "prettier";
+import { type AstPath, type Doc, doc } from "prettier";
 import { addIndentedStatements } from "./util/print-utils.ts";
 import { printArrayDefinition } from "./print-array-definition.ts";
 import { printDoStatement } from "./print-do-statement.ts";

--- a/src/prettier/print-array-definition.ts
+++ b/src/prettier/print-array-definition.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc, doc } from "prettier";
+import { type AstPath, type Doc, doc } from "prettier";
 import { addBreakingWhitespace, addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { ArrayDefinition } from "../ast/node/array-definition.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";

--- a/src/prettier/print-do-statement.ts
+++ b/src/prettier/print-do-statement.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc, doc } from "prettier";
+import { type AstPath, type Doc, doc } from "prettier";
 import { addBreakingWhitespace, addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { DoStatement } from "../ast/node/do-statement.ts";

--- a/src/prettier/print-elementary-type.ts
+++ b/src/prettier/print-elementary-type.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc } from "prettier";
+import { type AstPath, type Doc } from "prettier";
 import { addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { ElementaryType } from "../ast/node/elementary-type.ts";

--- a/src/prettier/print-for-statement.ts
+++ b/src/prettier/print-for-statement.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc } from "prettier";
+import { type AstPath, type Doc } from "prettier";
 import { addBreakingWhitespace, addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { ForStatement } from "../ast/node/for-statement.ts";

--- a/src/prettier/print-if-statement.ts
+++ b/src/prettier/print-if-statement.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc } from "prettier";
+import { type AstPath, type Doc } from "prettier";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { IfStatement } from "../ast/node/if-statement.ts";
 import {

--- a/src/prettier/print-map-entry.ts
+++ b/src/prettier/print-map-entry.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc, doc } from "prettier";
+import { type AstPath, type Doc, doc } from "prettier";
 import { addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { MapEntry } from "../ast/node/map-entry.ts";

--- a/src/prettier/print-parameter.ts
+++ b/src/prettier/print-parameter.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc, doc } from "prettier";
+import { type AstPath, type Doc, doc } from "prettier";
 import { addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { Parameter } from "../ast/node/parameter.ts";

--- a/src/prettier/print-specification.ts
+++ b/src/prettier/print-specification.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc, doc } from "prettier";
+import { type AstPath, type Doc, doc } from "prettier";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { AbstractStatement } from "../ast/node/abstract-statement.ts";
 import { NodeKind } from "../ast/node/enum/node-kind.ts";

--- a/src/prettier/print-string-literal.ts
+++ b/src/prettier/print-string-literal.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc } from "prettier";
+import { type AstPath, type Doc } from "prettier";
 import type { StringLiteral } from "../ast/node/string-literal.ts";
 import { isMissingError, isUnexpectedError } from "../ast/util/types.ts";
 import type { AbstractNode, Token } from "../../index.ts";

--- a/src/prettier/print-switch-statement.ts
+++ b/src/prettier/print-switch-statement.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc } from "prettier";
+import { type AstPath, type Doc } from "prettier";
 import { addIndentedStatements, addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { SwitchStatement } from "../ast/node/switch-statement.ts";

--- a/src/prettier/print-while-statement.ts
+++ b/src/prettier/print-while-statement.ts
@@ -1,4 +1,4 @@
-import { AstPath, type Doc } from "prettier";
+import { type AstPath, type Doc } from "prettier";
 import { addNonBreakingWhitespace } from "./util/print-utils.ts";
 import type { AbstractNode } from "../ast/node/abstract-node.ts";
 import type { WhileStatement } from "../ast/node/while-statement.ts";


### PR DESCRIPTION
## Summary
- `AstPath` was imported as a runtime value in 13 prettier printer files, but is only ever used as a TypeScript type (generic annotations, `as AstPath<...>` casts).
- prettier's `standalone.mjs` build does not export `AstPath` at runtime, so consumers bundling this package (e.g. Bun's bundler) fail with:
  `error: No matching export in "prettier/standalone.mjs" for import "AstPath"`
- Changed each affected import to `type AstPath` (or added `type` inline in mixed imports) so no runtime import is emitted.

## Test plan
- [x] `tsc -p tsconfig.build.json` passes with no errors
- [ ] Downstream consumer (`mpeg-sdl-editor`) `bun run build` succeeds against this branch